### PR TITLE
Fkeys

### DIFF
--- a/fkey_test.go
+++ b/fkey_test.go
@@ -78,7 +78,7 @@ func TestBasicForeignKeySimpleGet(t *testing.T) {
 
 func TestBasicForeignKeyMultiSelect(t *testing.T) {
 	dbmap := initDbMap()
-	//defer dropAndClose(dbmap)
+	defer dropAndClose(dbmap)
 
 	l := &BasicLeft{
 		Name: "foo",

--- a/fkey_test.go
+++ b/fkey_test.go
@@ -150,7 +150,7 @@ func TestBasicForeignKeyMultiSelect(t *testing.T) {
 
 func TestBasicForeignKeyConsolidatedMultiSelect(t *testing.T) {
 	dbmap := initDbMap()
-	//defer dropAndClose(dbmap)
+	defer dropAndClose(dbmap)
 
 	l := &BasicLeft{
 		Name: "foo",
@@ -195,6 +195,6 @@ func TestBasicForeignKeyConsolidatedMultiSelect(t *testing.T) {
 	}
 	loadedL := results[0].(*BasicLeft)
 	if len(loadedL.Rights) != 2 {
-		t.Errorf("Expected exactly two rights for left ID %d", l.ID)
+		t.Errorf("Expected exactly two rights for left ID %d, got %d", l.ID, len(loadedL.Rights))
 	}
 }

--- a/fkey_test.go
+++ b/fkey_test.go
@@ -6,7 +6,7 @@ type BasicLeft struct {
 	ID     int
 	Name   string
 	Foo    string
-	Rights []*BasicRight `db:"-,fkey"`
+	Rights []*BasicRight `db:"-,fkey,join=basic_right_"`
 }
 
 type BasicRight struct {
@@ -145,5 +145,56 @@ func TestBasicForeignKeyMultiSelect(t *testing.T) {
 	}
 	if loadedR.Left.Foo != l.Foo {
 		t.Errorf("%v != %v", loadedR.Left.Foo, l.Foo)
+	}
+}
+
+func TestBasicForeignKeyConsolidatedMultiSelect(t *testing.T) {
+	dbmap := initDbMap()
+	//defer dropAndClose(dbmap)
+
+	l := &BasicLeft{
+		Name: "foo",
+		Foo:  "this is definitely a foo",
+	}
+	err := dbmap.Insert(l)
+	if err != nil {
+		t.Errorf("Error is non-nil: %s", err)
+	}
+
+	r1 := &BasicRight{
+		Name: "bar 1",
+		Bar:  "this is definitely a bar",
+		Left: l,
+	}
+	err = dbmap.Insert(r1)
+	if err != nil {
+		t.Fatalf("Error is non-nil: %s", err)
+	}
+
+	r2 := &BasicRight{
+		Name: "bar 2",
+		Bar:  "this is definitely another bar",
+		Left: l,
+	}
+	err = dbmap.Insert(r2)
+	if err != nil {
+		t.Fatalf("Error is non-nil: %s", err)
+	}
+
+	sql := `select basic_left.id, basic_left.name, basic_left.foo, ` +
+		`basic_right.id as basic_right_id, basic_right.name as basic_right_name, basic_right.bar as basic_right_bar ` +
+		"from basic_left " +
+		"inner join basic_right on basic_left.id = basic_right.basic_left_id " +
+		"where basic_left.id = " + dbmap.Dialect.BindVar(0)
+	results, err := dbmap.Select(&BasicLeft{}, sql, l.ID)
+	if err != nil {
+		t.Fatalf("Error is non-nil: %s", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("Expected exactly one result for ID %d", l.ID)
+	}
+	loadedL := results[0].(*BasicLeft)
+	if len(loadedL.Rights) != 2 {
+		t.Errorf("Expected exactly two rights for left ID %d", l.ID)
 	}
 }

--- a/fkey_test.go
+++ b/fkey_test.go
@@ -40,15 +40,6 @@ type MtoMThreeMapper struct {
 	Rank      int
 }
 
-// dbmap.AddTableWithName(BasicLeft{}, "basic_left").SetKeys(true, "ID")
-// r := BasicRight{}
-// dbmap.AddTableWithName(&r, "basic_right").SetKeys(true, &r.ID)
-// mainTable := dbmap.AddTableWithName(MtoMOne{}, "many_to_many_one").SetKeys(true, "ID")
-// dbmap.AddTableWithName(MtoMTwo{}, "many_to_many_two").SetKeys(true, "ID")
-// mainTable.ManyToMany(MtoMTwo{})
-// mainTable.ManyToManyWithName(MtoMThreeMapper{}, "one_three_map").SetKeys(true, "MapID")
-// dbmap.AddTableWithName(MtoMOne{}, "many_to_many_one").SetKeys(true, "ID")
-
 func TestBasicForeignKeySimpleGet(t *testing.T) {
 	dbmap := initDbMap()
 	defer dropAndClose(dbmap)

--- a/fkey_test.go
+++ b/fkey_test.go
@@ -1,0 +1,127 @@
+package gorp
+
+import "testing"
+
+type BasicLeft struct {
+	ID     int
+	Name   string
+	Rights []*BasicRight `db:"-,fkey"`
+}
+
+type BasicRight struct {
+	ID   int
+	Name string
+	Left *BasicLeft `db:",fkey"`
+}
+
+type MtoMOne struct {
+	ID   int
+	Name string
+	Twos []*MtoMTwo `db:"-,fkey"`
+}
+
+type MtoMTwo struct {
+	ID   int
+	Name string
+	Ones []*MtoMOne `db:"-,fkey"`
+}
+
+type MtoMThree struct {
+	ID   int
+	Name string
+}
+
+type MtoMThreeMapper struct {
+	MapID     int `db:"id"`
+	MtoMThree `db:",fkey"`
+	One       *MtoMOne `db:",fkey"`
+	Rank      int
+}
+
+// dbmap.AddTableWithName(BasicLeft{}, "basic_left").SetKeys(true, "ID")
+// r := BasicRight{}
+// dbmap.AddTableWithName(&r, "basic_right").SetKeys(true, &r.ID)
+// mainTable := dbmap.AddTableWithName(MtoMOne{}, "many_to_many_one").SetKeys(true, "ID")
+// dbmap.AddTableWithName(MtoMTwo{}, "many_to_many_two").SetKeys(true, "ID")
+// mainTable.ManyToMany(MtoMTwo{})
+// mainTable.ManyToManyWithName(MtoMThreeMapper{}, "one_three_map").SetKeys(true, "MapID")
+// dbmap.AddTableWithName(MtoMOne{}, "many_to_many_one").SetKeys(true, "ID")
+
+func TestBasicForeignKeySimpleGet(t *testing.T) {
+	dbmap := initDbMap()
+	defer dropAndClose(dbmap)
+
+	l := &BasicLeft{}
+	err := dbmap.Insert(l)
+	if err != nil {
+		t.Errorf("Error is non-nil: %s", err)
+	}
+
+	r := &BasicRight{Left: l}
+	err = dbmap.Insert(r)
+	if err != nil {
+		t.Fatalf("Error is non-nil: %s", err)
+	}
+
+	// A normal get should still load the ID
+	result, err := dbmap.Get(&BasicRight{}, r.ID)
+	if err != nil {
+		t.Fatalf("Error is non-nil: %s", err)
+	}
+	loadedR, ok := result.(*BasicRight)
+	if !ok {
+		t.Fatalf("Expected result to be a BasicRight pointer")
+	}
+	if loadedR.ID != r.ID {
+		t.Errorf("%v != %v", loadedR.ID, r.ID)
+	}
+	if loadedR.Left == nil {
+		t.Fatalf("Expected Left to be loaded")
+	}
+	if loadedR.Left.ID != l.ID {
+		t.Errorf("%v != %v", loadedR.Left.ID, l.ID)
+	}
+}
+
+func TestBasicForeignKeyMultiSelect(t *testing.T) {
+	dbmap := initDbMap()
+	//defer dropAndClose(dbmap)
+
+	l := &BasicLeft{}
+	err := dbmap.Insert(l)
+	if err != nil {
+		t.Errorf("Error is non-nil: %s", err)
+	}
+
+	r := &BasicRight{Left: l}
+	err = dbmap.Insert(r)
+	if err != nil {
+		t.Fatalf("Error is non-nil: %s", err)
+	}
+
+	sql := `select basic_right.id, basic_right.name, basic_left.id, basic_left.name ` +
+		"from basic_left " +
+		"inner join basic_right on basic_left.id = basic_right.basic_left_id " +
+		"where basic_right.id = " + dbmap.Dialect.BindVar(0)
+	results, err := dbmap.Select(&BasicRight{}, sql, r.ID)
+	if err != nil {
+		t.Fatalf("Error is non-nil: %s", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("Expected exactly one result for ID %d", r.ID)
+	}
+
+	loadedR, ok := results[0].(*BasicRight)
+	if !ok {
+		t.Fatalf("Expected result to be a BasicRight pointer")
+	}
+	if loadedR.ID != r.ID {
+		t.Errorf("%v != %v", loadedR.ID, r.ID)
+	}
+	if loadedR.Left == nil {
+		t.Fatalf("Expected Left to be loaded")
+	}
+	if loadedR.Left.ID != l.ID {
+		t.Errorf("%v != %v", loadedR.Left.ID, l.ID)
+	}
+}

--- a/gorp.go
+++ b/gorp.go
@@ -298,10 +298,14 @@ func (t *TableMap) readStructColumns(v reflect.Value, typ reflect.Type) (cols []
 			if targetType.Kind() != reflect.Struct {
 				panic("Foreign keys that are not structs or pointers to structs cannot be mapped to real columns (hint: `db:\"-,fkey\"`)")
 			}
-			var err error
-			targetTable, err = t.dbmap.TableFor(targetType, true)
-			if err != nil {
-				panic(fmt.Errorf("Could not find previously mapped table for foreign key type %s: %s", targetType.Name(), err))
+			if targetType == t.gotype {
+				targetTable = t
+			} else {
+				var err error
+				targetTable, err = t.dbmap.TableFor(targetType, true)
+				if err != nil {
+					panic(fmt.Errorf("Could not find previously mapped table for foreign key type %s: %s", targetType.Name(), err))
+				}
 			}
 			for _, key := range targetTable.keys {
 				cm := &ColumnMap{

--- a/gorp.go
+++ b/gorp.go
@@ -314,12 +314,12 @@ func (t *TableMap) readStructColumns(v reflect.Value, typ reflect.Type) (cols []
 					origtype:   key.origtype,
 					gotype:     key.gotype,
 					joinAlias:  key.joinAlias,
-					references: &reference{
+					references: &Reference{
 						table:  targetTable,
 						column: key,
 					},
 				}
-				key.referencedBy = append(key.referencedBy, &reference{
+				key.referencedBy = append(key.referencedBy, &Reference{
 					table:  t,
 					column: cm,
 				})
@@ -855,7 +855,7 @@ func (t *TableMap) bindGet() bindPlan {
 	return plan
 }
 
-type reference struct {
+type Reference struct {
 	table  *TableMap
 	column *ColumnMap
 }
@@ -894,18 +894,35 @@ type ColumnMap struct {
 	isNotNull  bool
 
 	joinAlias    string
-	references   *reference
-	referencedBy []*reference
+	references   *Reference
+	referencedBy []*Reference
 }
 
 // JoinAlias returns a column name alias that can be used when
-// performing joined queries.
+// performing joined queries.  Embedded structs that map to tables
+// will prefix this to all child fields' join aliases.
 func (c *ColumnMap) JoinAlias() string {
 	return c.joinAlias
 }
 
+// SetJoinAlias sets the join alias for this column.
 func (c *ColumnMap) SetJoinAlias(alias string) {
 	c.joinAlias = alias
+}
+
+// References returns the table and column (in a *reference instance)
+// which this column references as a foreign key.
+//
+// TODO: Add setter
+func (c *ColumnMap) References() *Reference {
+	return c.references
+}
+
+// ReferencedBy returns a list of all tables and columns (in a
+// []*reference instance) which reference this column.  You cannot set
+// this value directly.
+func (c *ColumnMap) ReferencedBy() []*Reference {
+	return c.referencedBy
 }
 
 // Rename allows you to specify the column name in the table

--- a/gorp.go
+++ b/gorp.go
@@ -855,9 +855,20 @@ func (t *TableMap) bindGet() bindPlan {
 	return plan
 }
 
+// A Reference represents a foreign key relationship.
 type Reference struct {
 	table  *TableMap
 	column *ColumnMap
+}
+
+// Table returns the table that this reference points to.
+func (r *Reference) Table() *TableMap {
+	return r.table
+}
+
+// Column returns the column that this reference points to.
+func (r *Reference) Column() *ColumnMap {
+	return r.column
 }
 
 // ColumnMap represents a mapping between a Go struct field and a single

--- a/gorp.go
+++ b/gorp.go
@@ -309,7 +309,7 @@ func (t *TableMap) readStructColumns(v reflect.Value, typ reflect.Type) (cols []
 			}
 			for _, key := range targetTable.keys {
 				cm := &ColumnMap{
-					ColumnName: fmt.Sprintf("%s_%s", joinAlias, key.ColumnName),
+					ColumnName: joinAlias + key.ColumnName,
 					fieldIndex: append(f.Index, key.fieldIndex...),
 					origtype:   key.origtype,
 					gotype:     key.gotype,

--- a/gorp.go
+++ b/gorp.go
@@ -252,7 +252,7 @@ func (t *TableMap) readStructColumns(v reflect.Value, typ reflect.Type) (cols []
 			for _, subcol := range subcols {
 				subcol.fieldIndex = append(f.Index, subcol.fieldIndex...)
 				if fakeAnonymous {
-					subcol.fieldName = fmt.Sprintf("%s.%s", columnName, subcol.fieldName)
+					subcol.fieldName = fmt.Sprintf("%s.%s", f.Name, subcol.fieldName)
 				}
 				shouldAppend := true
 				for _, col := range cols {

--- a/gorp.go
+++ b/gorp.go
@@ -2000,7 +2000,7 @@ func rawselect(m *DbMap, exec SqlExecutor, i interface{}, query string,
 		}
 
 		shouldAppend := true
-		if multiJoinCols != nil {
+		if multiJoinCols != nil && table != nil {
 			// There are slice elements in the type that are being
 			// filled out by values in the query.  This means the
 			// select is probably a many-to-many or one-to-many join

--- a/gorp.go
+++ b/gorp.go
@@ -935,6 +935,12 @@ type ColumnMap struct {
 	referencedBy []*Reference
 }
 
+// FieldIndex returns the index (intended to be used by
+// reflect.Value.FieldByIndex) for this column within its type.
+func (c *ColumnMap) FieldIndex() []int {
+	return c.fieldIndex
+}
+
 // JoinAlias returns a column name alias that can be used when
 // performing joined queries.  Embedded structs that map to tables
 // will prefix this to all child fields' join aliases.

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -726,7 +726,7 @@ func TestOverrideVersionCol(t *testing.T) {
 	}
 	defer dropAndClose(dbmap)
 	c1 := t1.SetVersionCol("LegacyVersion")
-	if c1.ColumnName != "LegacyVersion" {
+	if c1.ColumnName != "legacyversion" {
 		t.Errorf("Wrong col returned: %v", c1)
 	}
 

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -6,10 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	_ "github.com/go-sql-driver/mysql"
-	_ "github.com/lib/pq"
-	_ "github.com/mattn/go-sqlite3"
-	_ "github.com/ziutek/mymysql/godrv"
 	"log"
 	"math/rand"
 	"os"
@@ -17,6 +13,11 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	_ "github.com/lib/pq"
+	_ "github.com/mattn/go-sqlite3"
+	_ "github.com/ziutek/mymysql/godrv"
 )
 
 // verify interface compliance
@@ -1931,6 +1932,16 @@ func initDbMap() *DbMap {
 	dbmap.AddTableWithName(WithEmbeddedStructBeforeAutoincrField{}, "embedded_struct_before_autoincr_test").SetKeys(true, "Id")
 	dbmap.AddTableWithName(WithEmbeddedAutoincr{}, "embedded_autoincr_test").SetKeys(true, "Id")
 	dbmap.AddTableWithName(WithTime{}, "time_test").SetKeys(true, "Id")
+
+	// tables with foreign keys
+	dbmap.AddTableWithName(BasicLeft{}, "basic_left").SetKeys(true, "ID")
+	r := BasicRight{}
+	dbmap.AddTableWithName(&r, "basic_right").SetKeys(true, &r.ID)
+	mainTable := dbmap.AddTableWithName(MtoMOne{}, "many_to_many_one").SetKeys(true, "ID")
+	dbmap.AddTableWithName(MtoMThree{}, "many_to_many_three").SetKeys(true, "ID")
+	mainTable.ManyToManyWithName(MtoMThreeMapper{}, "one_three_map").SetKeys(true, "MapID")
+	dbmap.AddTableWithName(MtoMOne{}, "many_to_many_one").SetKeys(true, "ID")
+
 	dbmap.TypeConverter = testTypeConverter{}
 	err := dbmap.DropTablesIfExists()
 	if err != nil {

--- a/migration_manager.go
+++ b/migration_manager.go
@@ -325,7 +325,7 @@ func (m *MigrationManager) migrateTable(oldTable, newTable *tableRecord) (err er
 				}
 				break
 			}
-			if oldCol.FieldName == newCol.FieldName {
+			if oldCol.FieldName != "" && oldCol.FieldName == newCol.FieldName {
 				found = true
 				oldQuotedColumn := m.dbMap.Dialect.QuoteField(oldCol.ColumnName)
 				sql := "ALTER TABLE " + quotedTable + " RENAME COLUMN " + oldQuotedColumn + " TO " + quotedColumn

--- a/migration_manager.go
+++ b/migration_manager.go
@@ -128,7 +128,7 @@ type MigrationManager struct {
 func (m *MigrationManager) layoutFor(t *TableMap) []columnLayout {
 	l := make([]columnLayout, 0, len(t.Columns))
 	for _, colMap := range t.Columns {
-		if colMap.ColumnName == "-" {
+		if colMap.Transient {
 			continue
 		}
 		var stype string


### PR DESCRIPTION
Lots of altered functionality dealing with foreign keys and how they map to nested struct fields.  This allows, for example:

```go
type foo struct {
    ID int
    Bars []bar `db:"-,fkey,join=bar_"`
}

type bar struct {
    ID int
    Foo foo `db:",fkey,join=foo_"`

dbMap.AddTable(foo).SetKeys(true, "ID")
dbMap.AddTable(bar).SetKeys(true, "ID")
dbMap.CreateTables()
res, err := dbMap.Select(foo{}, "select foo.id, bar.id as bar_id from foos inner join bars on foos.id = bars.foo_id where foo.id = $1", someID)
res[0].(foo).Bars[0].ID == bar.ID
```